### PR TITLE
Complex creature form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,6 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'jquery-rails'
+gem 'cocoon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
     chromedriver-helper (2.1.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    cocoon (1.2.12)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -87,6 +88,10 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    jquery-rails (4.3.3)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -207,8 +212,10 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   chromedriver-helper
+  cocoon
   coffee-rails (~> 4.2)
   jbuilder (~> 2.5)
+  jquery-rails
   listen (>= 3.0.5, < 3.2)
   mysql2 (>= 0.4.4, < 0.6.0)
   puma (~> 3.11)
@@ -226,4 +233,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.6
+   1.17.1

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,8 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require jquery3
+//= require cocoon
 //= require rails-ujs
 //= require activestorage
 //= require turbolinks

--- a/app/assets/stylesheets/_util.scss
+++ b/app/assets/stylesheets/_util.scss
@@ -1,0 +1,48 @@
+.flex-10 {
+  flex-basis: 10%;
+  max-width: 10%;
+}
+.flex-20 {
+  flex-basis: 20%;
+  max-width: 20%;
+}
+.flex-25 {
+  flex-basis: 25%;
+  max-width: 25%;
+}
+.flex-30 {
+  flex-basis: 30%;
+  max-width: 30%;
+}
+.flex-40 {
+  flex-basis: 40%;
+  max-width: 40%;
+}
+.flex-50 {
+  flex-basis: 50%;
+  max-width: 50%;
+}
+.flex-60 {
+  flex-basis: 60%;
+  max-width: 60%;
+}
+.flex-70 {
+  flex-basis: 70%;
+  max-width: 70%;
+}
+.flex-75 {
+  flex-basis: 75%;
+  max-width: 75%;
+}
+.flex-80 {
+  flex-basis: 80%;
+  max-width: 80%;
+}
+.flex-90 {
+  flex-basis: 90%;
+  max-width: 90%;
+}
+.flex-100 {
+  flex-basis: 100%;
+  max-width: 100%;
+}

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -1,5 +1,6 @@
-@import "variables";
 @import "mixins";
+@import "util";
+@import "variables";
 
 *, *:before, *:after {
   box-sizing: inherit;
@@ -90,7 +91,7 @@ main {
   min-height: 100%;
 }
 
-input.field {
+input {
   &[type=button], &[type=submit], &[type=reset] {
     @include button($nav-color);
     color: $nav-text;
@@ -100,22 +101,30 @@ input.field {
     border: none;
     cursor: pointer;
   }
+}
 
+input:not(.addon-field) {
   &:not([type=submit]):not([type=reset]):not([type=button]):not([type=file]) {
     @include text-input($main-color, $nav-color);
   }
 }
 
-select.field {
+select {
   @include text-input($main-color, $nav-color);
 }
 
 div.field {
+  margin: 10px 0px;
+
   label {
     display: block;
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
   }
+}
+
+div.actions {
+  margin: 10px 0px;
 }
 
 .addon-container {
@@ -145,4 +154,27 @@ div.field {
 
 .push-right {
   margin-left: auto;
+}
+
+.fields-horizontal {
+  display: inline-flex;
+}
+
+.field-item {
+  flex: 1 1 auto;
+  margin: 0px 10px;
+  &:first-child {
+    margin-left: 0px;
+  }
+  &:last-child {
+    margin-right: 0px;
+  }
+  & * {
+    width: 100%;
+  }
+  & label {
+    display: block;
+    margin-top: 0.25rem;
+    margin-bottom: 0.25rem;
+  }
 }

--- a/app/controllers/creatures_controller.rb
+++ b/app/controllers/creatures_controller.rb
@@ -101,7 +101,23 @@ class CreaturesController < ApplicationController
         :darkvision,
         :tremorsense,
         :truesight,
-        :challenge
+        :challenge,
+        creature_actions_attributes: [
+          :id,
+          :name,
+          :damage_dice,
+          :description,
+          :range,
+          :_destroy,
+        ],
+        abilities_attributes: [:id, :name, :description, :_destroy],
+        skills_attributes: [:id, :name, :bonus, :_destroy],
+        spells_attributes: [:id, :name, :description, :level, :dice, :_destroy],
+        damage_immunities_attributes: [:id, :name, :_destroy],
+        damage_vulnerabilities_attributes: [:id, :name, :_destroy],
+        damage_resistances_attributes: [:id, :name, :_destroy],
+        condition_immunities_attributes: [:id, :name, :_destroy],
+        languages_attributes: [:id, :name, :_destroy],
       )
     end
 end

--- a/app/models/creature.rb
+++ b/app/models/creature.rb
@@ -13,6 +13,10 @@ class Creature < ApplicationRecord
   has_and_belongs_to_many :condition_immunities
   has_and_belongs_to_many :languages
 
+  accepts_nested_attributes_for :creature_actions, :skills, :abilities,
+    :spells, :damage_immunities, :damage_vulnerabilities, :damage_resistances,
+    :condition_immunities, :languages, allow_destroy: true, reject_if: :all_blank
+
   #validations here, with itself
   validates :name, :type, :size, :alignment, presence: true
   validates :ac, :hp, :speed, :swim, :burrow, :climb, :fly, :strength,

--- a/app/views/creatures/_ability_fields.html.erb
+++ b/app/views/creatures/_ability_fields.html.erb
@@ -1,0 +1,13 @@
+<div class="nested-fields">
+  <div class="field">
+    <%= f.label :name %>
+    <%= f.text_field :name %>
+  </div>
+
+  <div class="field">
+    <%= f.label :description %>
+    <%= f.text_area :description, size: "30x5" %>
+  </div>
+
+  <%= link_to_remove_association "Remove ability", f %>
+</div>

--- a/app/views/creatures/_condition_immunity_fields.html.erb
+++ b/app/views/creatures/_condition_immunity_fields.html.erb
@@ -1,0 +1,8 @@
+<div class="nested-fields">
+  <div class="field">
+    <%= f.label :name %>
+    <%= f.text_field :name, list: "condition-immunities-list" %>
+  </div>
+
+  <%= link_to_remove_association "Remove condition immunity", f %>
+</div>

--- a/app/views/creatures/_creature_action_fields.html.erb
+++ b/app/views/creatures/_creature_action_fields.html.erb
@@ -1,0 +1,23 @@
+<div class="nested-fields">
+  <div class="field">
+    <%= f.label :name %>
+    <%= f.text_field :name %>
+  </div>
+
+  <div class="field">
+    <%= f.label :damage_dice %>
+    <%= f.text_field :damage_dice %>
+  </div>
+
+  <div class="field">
+    <%= f.label :description %>
+    <%= f.text_field :description %>
+  </div>
+
+  <div class="field">
+    <%= f.label :range %>
+    <%= f.number_field :range %>
+  </div>
+
+  <%= link_to_remove_association "Remove action", f %>
+</div>

--- a/app/views/creatures/_damage_immunity_fields.html.erb
+++ b/app/views/creatures/_damage_immunity_fields.html.erb
@@ -1,0 +1,8 @@
+<div class="nested-fields">
+  <div class="field">
+    <%= f.label :name %>
+    <%= f.text_field :name, list: "damage-immunities-list" %>
+  </div>
+
+  <%= link_to_remove_association "Remove damage immunity", f %>
+</div>

--- a/app/views/creatures/_damage_resistance_fields.html.erb
+++ b/app/views/creatures/_damage_resistance_fields.html.erb
@@ -1,0 +1,8 @@
+<div class="nested-fields">
+  <div class="field">
+    <%= f.label :name %>
+    <%= f.text_field :name, list: "damage-resistances-list" %>
+  </div>
+  
+  <%= link_to_remove_association "Remove damage resistance", f %>
+</div>

--- a/app/views/creatures/_damage_vulnerability_fields.html.erb
+++ b/app/views/creatures/_damage_vulnerability_fields.html.erb
@@ -1,0 +1,8 @@
+<div class="nested-fields">
+  <div class="field">
+    <%= f.label :name %>
+    <%= f.text_field :name, list: "damage-vulnerabilities-list" %>
+  </div>
+  
+  <%= link_to_remove_association "Remove damage vulnerability", f %>
+</div>

--- a/app/views/creatures/_form.html.erb
+++ b/app/views/creatures/_form.html.erb
@@ -56,114 +56,114 @@
     <%= form.text_field :hp_dice, required: true %>
   </div>
 
-  <div class="field">
-    <%= form.label :speed %>
-    <%= form.number_field :speed, required: true %>
+  <h3>Speed</h3>
+
+  <div class="fields-horizontal">
+    <div class="field-item flex-10">
+      <%= form.label :speed %>
+      <%= form.number_field :speed, required: true %>
+    </div>
+    <div class="field-item flex-10">
+      <%= form.label :swim %>
+      <%= form.number_field :swim, required: true %>
+    </div>
+    <div class="field-item flex-10">
+      <%= form.label :burrow %>
+      <%= form.number_field :burrow, required: true %>
+    </div>
+    <div class="field-item flex-10">
+      <%= form.label :climb %>
+      <%= form.number_field :climb, required: true %>
+    </div>
+    <div class="field-item flex-10">
+      <%= form.label :fly %>
+      <%= form.number_field :fly, required: true %>
+    </div>
   </div>
 
-  <div class="field">
-    <%= form.label :swim %>
-    <%= form.number_field :swim, required: true %>
+  <h3>Stats</h3>
+
+  <div class="fields-horizontal">
+    <div class="field-item flex-10">
+      <%= form.label :strength %>
+      <%= form.number_field :strength, required: true %>
+    </div>
+    <div class="field-item flex-10">
+      <%= form.label :dexterity %>
+      <%= form.number_field :dexterity, required: true %>
+    </div>
+    <div class="field-item flex-10">
+      <%= form.label :constitution %>
+      <%= form.number_field :constitution, required: true %>
+    </div>
+    <div class="field-item flex-10">
+      <%= form.label :intellect %>
+      <%= form.number_field :intellect, required: true %>
+    </div>
+
+    <div class="field-item flex-10">
+      <%= form.label :wisdom %>
+      <%= form.number_field :wisdom, required: true %>
+    </div>
+
+    <div class="field-item flex-10">
+      <%= form.label :charisma %>
+      <%= form.number_field :charisma, required: true %>
+    </div>
   </div>
 
-  <div class="field">
-    <%= form.label :burrow %>
-    <%= form.number_field :burrow, required: true %>
+  <h3>Saving Throws</h3>
+
+  <div class="fields-horizontal">
+    <div class="field-item flex-10">
+      <%= form.label :str_saving %>
+      <%= form.number_field :str_saving, required: true %>
+    </div>
+    <div class="field-item flex-10">
+      <%= form.label :dex_saving %>
+      <%= form.number_field :dex_saving, required: true %>
+    </div>
+    <div class="field-item flex-10">
+      <%= form.label :con_saving %>
+      <%= form.number_field :con_saving, required: true %>
+    </div>
+    <div class="field-item flex-10">
+      <%= form.label :int_saving %>
+      <%= form.number_field :int_saving, required: true %>
+    </div>
+    <div class="field-item flex-10">
+      <%= form.label :wis_saving %>
+      <%= form.number_field :wis_saving, required: true %>
+    </div>
+    <div class="field-item flex-10">
+      <%= form.label :chr_saving %>
+      <%= form.number_field :chr_saving, required: true %>
+    </div>
   </div>
 
-  <div class="field">
-    <%= form.label :climb %>
-    <%= form.number_field :climb, required: true %>
-  </div>
+  <h3>Senses</h3>
 
-  <div class="field">
-    <%= form.label :fly %>
-    <%= form.number_field :fly, required: true %>
-  </div>
-
-  <div class="field">
-    <%= form.label :strength %>
-    <%= form.number_field :strength, required: true %>
-  </div>
-
-  <div class="field">
-    <%= form.label :dexterity %>
-    <%= form.number_field :dexterity, required: true %>
-  </div>
-
-  <div class="field">
-    <%= form.label :constitution %>
-    <%= form.number_field :constitution, required: true %>
-  </div>
-
-  <div class="field">
-    <%= form.label :intellect %>
-    <%= form.number_field :intellect, required: true %>
-  </div>
-
-  <div class="field">
-    <%= form.label :wisdom %>
-    <%= form.number_field :wisdom, required: true %>
-  </div>
-
-  <div class="field">
-    <%= form.label :charisma %>
-    <%= form.number_field :charisma, required: true %>
-  </div>
-
-  <div class="field">
-    <%= form.label :str_saving %>
-    <%= form.number_field :str_saving, required: true %>
-  </div>
-
-  <div class="field">
-    <%= form.label :dex_saving %>
-    <%= form.number_field :dex_saving, required: true %>
-  </div>
-
-  <div class="field">
-    <%= form.label :con_saving %>
-    <%= form.number_field :con_saving, required: true %>
-  </div>
-
-  <div class="field">
-    <%= form.label :int_saving %>
-    <%= form.number_field :int_saving, required: true %>
-  </div>
-
-  <div class="field">
-    <%= form.label :wis_saving %>
-    <%= form.number_field :wis_saving, required: true %>
-  </div>
-
-  <div class="field">
-    <%= form.label :chr_saving %>
-    <%= form.number_field :chr_saving, required: true %>
-  </div>
-
-  <div class="field">
-    <%= form.label :perception %>
-    <%= form.number_field :perception, required: true %>
-  </div>
-
-  <div class="field">
-    <%= form.label :blindsight %>
-    <%= form.number_field :blindsight, required: true %>
-  </div>
-
-  <div class="field">
-    <%= form.label :darkvision %>
-    <%= form.number_field :darkvision, required: true %>
-  </div>
-
-  <div class="field">
-    <%= form.label :tremorsense %>
-    <%= form.number_field :tremorsense, required: true %>
-  </div>
-
-  <div class="field">
-    <%= form.label :truesight %>
-    <%= form.number_field :truesight, required: true %>
+  <div class="fields-horizontal">
+    <div class="field-item flex-10">
+      <%= form.label :perception %>
+      <%= form.number_field :perception, required: true %>
+    </div>
+    <div class="field-item flex-10">
+      <%= form.label :blindsight %>
+      <%= form.number_field :blindsight, required: true %>
+    </div>
+    <div class="field-item flex-10">
+      <%= form.label :darkvision %>
+      <%= form.number_field :darkvision, required: true %>
+    </div>
+    <div class="field-item flex-10">
+      <%= form.label :tremorsense %>
+      <%= form.number_field :tremorsense, required: true %>
+    </div>
+    <div class="field-item flex-10">
+      <%= form.label :truesight %>
+      <%= form.number_field :truesight, required: true %>
+    </div>
   </div>
 
   <div class="field">

--- a/app/views/creatures/_form.html.erb
+++ b/app/views/creatures/_form.html.erb
@@ -117,27 +117,27 @@
   <div class="fields-horizontal">
     <div class="field-item flex-10">
       <%= form.label :str_saving %>
-      <%= form.number_field :str_saving, required: true %>
+      <%= form.number_field :str_saving %>
     </div>
     <div class="field-item flex-10">
       <%= form.label :dex_saving %>
-      <%= form.number_field :dex_saving, required: true %>
+      <%= form.number_field :dex_saving %>
     </div>
     <div class="field-item flex-10">
       <%= form.label :con_saving %>
-      <%= form.number_field :con_saving, required: true %>
+      <%= form.number_field :con_saving %>
     </div>
     <div class="field-item flex-10">
       <%= form.label :int_saving %>
-      <%= form.number_field :int_saving, required: true %>
+      <%= form.number_field :int_saving %>
     </div>
     <div class="field-item flex-10">
       <%= form.label :wis_saving %>
-      <%= form.number_field :wis_saving, required: true %>
+      <%= form.number_field :wis_saving %>
     </div>
     <div class="field-item flex-10">
       <%= form.label :chr_saving %>
-      <%= form.number_field :chr_saving, required: true %>
+      <%= form.number_field :chr_saving %>
     </div>
   </div>
 
@@ -171,7 +171,124 @@
     <%= form.number_field :challenge, required: true %>
   </div>
 
+  <h2>Damage Immunities</h2>
+
+  <div id="damage_immunities">
+    <%= form.fields_for :damage_immunities do |fields| %>
+      <%= render "damage_immunity_fields", f: fields %>
+    <% end %>
+    <%= link_to_add_association "Add damage immunity", form, :damage_immunities %>
+  </div>
+
+  <h2>Damage Vulnerabilities</h2>
+
+  <div id="damage_vulnerabilities">
+    <%= form.fields_for :damage_vulnerabilities do |fields| %>
+      <%= render "damage_vulnerability_fields", f: fields %>
+    <% end %>
+    <%= link_to_add_association "Add damage vulnerability", form, :damage_vulnerabilities %>
+  </div>
+
+  <h2>Damage Resistances</h2>
+
+  <div id="damage_resistances">
+    <%= form.fields_for :damage_resistances do |fields| %>
+      <%= render "damage_resistance_fields", f: fields %>
+    <% end %>
+    <%= link_to_add_association "Add damage resistance", form, :damage_resistances %>
+  </div>
+
+  <h2>Condition Immunities</h2>
+
+  <div id="condition_immunities">
+    <%= form.fields_for :condition_immunities do |fields| %>
+      <%= render "condition_immunity_fields", f: fields %>
+    <% end %>
+    <%= link_to_add_association "Add condition immunity", form, :condition_immunities %>
+  </div>
+
+  <h2>Languages</h2>
+
+  <div id="languages">
+    <%= form.fields_for :languages do |fields| %>
+      <%= render "language_fields", f: fields %>
+    <% end %>
+    <%= link_to_add_association "Add language", form, :languages %>
+  </div>
+
+  <h2>Skills</h2>
+
+  <div id="skills">
+    <%= form.fields_for :skills do |fields| %>
+      <%= render "skill_fields", f: fields %>
+    <% end %>
+    <%= link_to_add_association "Add skill", form, :skills %>
+  </div>
+
+  <h2>Actions</h2>
+
+  <div id="creature_actions">
+    <%= form.fields_for :creature_actions do |fields| %>
+      <%= render "creature_action_fields", f: fields %>
+    <% end %>
+    <%= link_to_add_association "Add action", form, :creature_actions %>
+  </div>
+
+  <h2>Abilities</h2>
+
+  <div id="abilities">
+    <%= form.fields_for :abilities do |fields| %>
+      <%= render "ability_fields", f: fields %>
+    <% end %>
+    <%= link_to_add_association "Add ability", form, :abilities %>
+  </div>
+
+  <h2>Spells</h2>
+
+  <div id="spells">
+    <%= form.fields_for :spells do |fields| %>
+      <%= render "spell_fields", f: fields %>
+    <% end %>
+    <%= link_to_add_association "Add spell", form, :spells %>
+  </div>
+
   <div class="actions">
     <%= form.submit %>
   </div>
+
+  <datalist id="spells-list">
+    <% for spell in Spell.all do %>
+      <option><%= spell.name %></option>
+    <% end %>
+  </datalist>
+
+  <datalist id="damage-immunities-list">
+    <% for damage_immunity in DamageImmunity.all do %>
+      <option><%= damage_immunity.name %></option>
+    <% end %>
+  </datalist>
+
+  <datalist id="damage-vulnerabilities-list">
+    <% for damage_vulnerability in DamageVulnerability.all do %>
+      <option><%= damage_vulnerability.name %></option>
+    <% end %>
+  </datalist>
+
+  <datalist id="damage-resistances-list">
+    <% for damage_resistance in DamageResistance.all do %>
+      <option><%= damage_resistance.name %></option>
+    <% end %>
+  </datalist>
+
+  <datalist id="condition-immunities-list">
+    <% for condition_immunity in ConditionImmunity.all do %>
+      <option><%= condition_immunity.name %></option>
+    <% end %>
+  </datalist>
+
+  <datalist id="languages-list">
+    <% for language in Language.all do %>
+      <option><%= language.name %></option>
+    <% end %>
+  </datalist>
 <% end %>

--- a/app/views/creatures/_language_fields.html.erb
+++ b/app/views/creatures/_language_fields.html.erb
@@ -1,0 +1,8 @@
+<div class="nested-fields">
+  <div class="field">
+    <%= f.label :name %>
+    <%= f.text_field :name, list: "languages-list" %>
+  </div>
+
+  <%= link_to_remove_association "Remove language", f %>
+</div>

--- a/app/views/creatures/_skill_fields.html.erb
+++ b/app/views/creatures/_skill_fields.html.erb
@@ -1,0 +1,13 @@
+<div class="nested-fields">
+ <div class="field">
+   <%= f.label :name %>
+   <%= f.text_field :name, required: true %>
+ </div>
+
+ <div class="field">
+   <%= f.label :bonus %>
+   <%= f.number_field :bonus, required: true %>
+ </div>
+
+ <%= link_to_remove_association "Remove skill", f %>
+</div>

--- a/app/views/creatures/_spell_fields.html.erb
+++ b/app/views/creatures/_spell_fields.html.erb
@@ -1,0 +1,23 @@
+<div class="nested-fields">
+  <div class="field">
+    <%= f.label :name %>
+    <%= f.text_field :name, list: "spells-list" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :description %>
+    <%= f.text_field :description %>
+  </div>
+
+  <div class="field">
+    <%= f.label :dice %>
+    <%= f.text_field :dice %>
+  </div>
+
+  <div class="field">
+    <%= f.label :level %>
+    <%= f.number_field :level %>
+  </div>
+
+  <%= link_to_remove_association "Remove spell", f %>
+</div>

--- a/app/views/creatures/edit.html.erb
+++ b/app/views/creatures/edit.html.erb
@@ -1,6 +1,6 @@
 <h1>Editing Creature</h1>
 
-<%= render 'form', creature: @creature %>
+<%= render 'form', creature: @creature, new?: false %>
 
 <%= link_to 'Show', @creature %> |
 <%= link_to 'Back', creatures_path %>

--- a/app/views/creatures/new.html.erb
+++ b/app/views/creatures/new.html.erb
@@ -1,5 +1,5 @@
 <h1>New Creature</h1>
 
-<%= render 'form', creature: @creature %>
+<%= render 'form', creature: @creature, new?: true %>
 
 <%= link_to 'Back', creatures_path %>

--- a/app/views/creatures/show.html.erb
+++ b/app/views/creatures/show.html.erb
@@ -51,22 +51,22 @@
 <% if @creature.saving_throws? %>
 <h4>Saving Throws</h4>
 <p>
-  <% if @creature.str_saving? %>
+  <% if !@creature.str_saving.nil? %>
     Str +<%= @creature.str_saving %>
   <% end %>
-  <% if @creature.dex_saving? %>
+  <% if !@creature.dex_saving.nil? %>
     Dex +<%= @creature.dex_saving %>
   <% end %>
-  <% if @creature.con_saving? %>
+  <% if !@creature.con_saving.nil? %>
     Con +<%= @creature.con_saving %>
   <% end %>
-  <% if @creature.int_saving? %>
+  <% if !@creature.int_saving.nil? %>
     Int +<%= @creature.int_saving %>
   <% end %>
-  <% if @creature.wis_saving? %>
+  <% if !@creature.wis_saving.nil? %>
     Wis +<%= @creature.wis_saving %>
   <% end %>
-  <% if @creature.chr_saving? %>
+  <% if !@creature.chr_saving.nil? %>
     Chr +<%= @creature.chr_saving %>
   <% end %>
 </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,9 +37,9 @@ en:
         ac_type: AC type
         hp: HP
         hp_dice: HP dice
-        str_saving: Strength saving throw
-        dex_saving: Dexterity saving throw
-        con_saving: Constitution saving throw
-        int_saving: Intellect saving throw
-        wis_saving: Wisdom saving throw
-        chr_saving: Charisma saving throw
+        str_saving: Strength
+        dex_saving: Dexterity
+        con_saving: Constitution
+        int_saving: Intellect
+        wis_saving: Wisdom
+        chr_saving: Charisma

--- a/test/fixtures/spells.yml
+++ b/test/fixtures/spells.yml
@@ -1,5 +1,5 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-Fireball:
+fireball:
   name: fireball
   description: >
     A bright streak flashes from your pointing finger to a point you choose within 

--- a/test/models/spell_test.rb
+++ b/test/models/spell_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class SpellTest < ActiveSupport::TestCase
   setup do 
-    @spell = spells(:Fireball)
+    @spell = spells(:fireball)
   end
 
   test "name must be valid" do


### PR DESCRIPTION
Allows adding associated models from the creature form.

Currently broken:
- Cannot choose from existing models for many-to-many objects (spells, languages, etc.)
- Associated models not shown in the show page.